### PR TITLE
fix: result_json too big

### DIFF
--- a/client/test/test_save.py
+++ b/client/test/test_save.py
@@ -35,6 +35,15 @@ def test_fns_are_right_type():
         assert isinstance(f, SavedFunction)
 
 
+@memo
+def giant_list():
+    return [i for i in range(100000)]
+
+
+def test_giantlist():
+    x = giant_list()
+
+
 def test_savesave():
     # [todo] view logs
     print(g(4))
@@ -50,4 +59,7 @@ def test_biggies():
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
+
+    test_giantlist()
+
     test_biggies()


### PR DESCRIPTION
fixes #82. The problem was that the size of results_json could be unbounded. I fixed this by truncating after 100 items in dictionaries or lists.

I think we need a better answer here, so I've made a hacky fix for now. The problem to solve is how to make a nice visualisation that doesn't use up loads of space by default, but which can be expanded into a full thing if needed.

The ideal solution is to have xyz/web be able to view the pickles directly and only load the first megabyte or whatever and show that.